### PR TITLE
Add simple WordPress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# PSU Simple Booking
+
+This repository contains a simple WordPress plugin that allows visitors to submit bookings via a shortcode.
+
+## Installation
+
+1. Copy `psu-simple-booking.php` to your WordPress installation's `wp-content/plugins/psu-simple-booking` directory.
+2. Activate the **PSU Simple Booking** plugin from the WordPress admin.
+
+## Usage
+
+Add the `[psu_booking_form]` shortcode to any post or page. Form submissions are stored as a custom post type called **Booking**.

--- a/psu-simple-booking.php
+++ b/psu-simple-booking.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Plugin Name: PSU Simple Booking
+ * Description: A simple booking system for WordPress.
+ * Version: 1.0
+ * Author: Example Author
+ */
+
+// Register custom post type for bookings.
+function psu_booking_post_type() {
+    $labels = array(
+        'name'          => __('Bookings', 'psu-simple-booking'),
+        'singular_name' => __('Booking', 'psu-simple-booking'),
+    );
+
+    $args = array(
+        'labels'      => $labels,
+        'public'      => false,
+        'show_ui'     => true,
+        'supports'    => array('title'),
+        'has_archive' => false,
+    );
+
+    register_post_type('psu_booking', $args);
+}
+add_action('init', 'psu_booking_post_type');
+
+// Shortcode for booking form.
+function psu_booking_form_shortcode() {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['psu_booking_nonce'])) {
+        if (wp_verify_nonce($_POST['psu_booking_nonce'], 'psu_booking')) {
+            $name  = sanitize_text_field($_POST['psu_name']);
+            $email = sanitize_email($_POST['psu_email']);
+            $date  = sanitize_text_field($_POST['psu_date']);
+
+            $post_id = wp_insert_post(array(
+                'post_type'   => 'psu_booking',
+                'post_title'  => $name,
+                'post_status' => 'publish',
+            ));
+
+            if ($post_id) {
+                update_post_meta($post_id, 'psu_email', $email);
+                update_post_meta($post_id, 'psu_date', $date);
+                echo '<p>Thank you for your booking!</p>';
+            }
+        }
+    }
+
+    ob_start();
+    ?>
+    <form method="post">
+        <?php wp_nonce_field('psu_booking', 'psu_booking_nonce'); ?>
+        <p>
+            <label for="psu_name">Name</label><br>
+            <input type="text" name="psu_name" id="psu_name" required>
+        </p>
+        <p>
+            <label for="psu_email">Email</label><br>
+            <input type="email" name="psu_email" id="psu_email" required>
+        </p>
+        <p>
+            <label for="psu_date">Date</label><br>
+            <input type="date" name="psu_date" id="psu_date" required>
+        </p>
+        <p>
+            <button type="submit">Book</button>
+        </p>
+    </form>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('psu_booking_form', 'psu_booking_form_shortcode');


### PR DESCRIPTION
## Summary
- add plugin file `psu-simple-booking.php`
- document installation and usage in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684537ccf4e883319f74d3240a2b8f24